### PR TITLE
URL Cleanup

### DIFF
--- a/plugins/org.springsource.sts/makeWinIco.bat
+++ b/plugins/org.springsource.sts/makeWinIco.bat
@@ -4,7 +4,7 @@ REM This bat file needs to be run on a windows system.
 REM Similar command should also work on Linux but for
 REM some reason the version of imagemagick I had on Linux refused to store
 REM The 256x256 image uncompressed.
-REM See http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=24883
+REM See https://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=24883
 
 convert sts256.png -compress none ^
     "(" -clone 0 -resize 16x16 -compress none ")" ^


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=24883 migrated to:  
  https://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=24883 ([https](https://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=24883) result 200).