### PR TITLE
URL Cleanup

### DIFF
--- a/common/pom-parent.xml
+++ b/common/pom-parent.xml
@@ -350,8 +350,8 @@
 					-Dhttps.proxyHost=proxy.eng.vmware.com -Dhttps.proxyPort=3128 ${test.osvmargs}</test.vmargs> -->
 				<p2.qualifier>CI-B${bamboo.buildNumber}</p2.qualifier>
 				<p2.replaceQualifier>true</p2.replaceQualifier>
-				<!-- <http_proxy>http://proxy.eng.vmware.com:3128</http_proxy> -->
-				<!-- <https_proxy>http://proxy.eng.vmware.com:3128</https_proxy> -->
+				<!-- <http_proxy>https://proxy.eng.vmware.com:3128</http_proxy> -->
+				<!-- <https_proxy>https://proxy.eng.vmware.com:3128</https_proxy> -->
 			</properties>
 		</profile>
 		<profile>
@@ -504,7 +504,7 @@
 					<storepass>${signing.store.password}</storepass>
 					<keypass>${signing.key.password}</keypass>
 <!--					<tsa>https://ca.signfiles.com/tsa/get.aspx</tsa> -->
-					<tsa>http://sha256timestamp.ws.symantec.com/sha256/timestamp</tsa>
+					<tsa>https://sha256timestamp.ws.symantec.com/sha256/timestamp</tsa>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/features/org.springsource.ggts.package.e3.7/feature.xml
+++ b/features/org.springsource.ggts.package.e3.7/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Groovy/Grails Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
-      <discovery label="Groovy/Grails Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <update label="Groovy/Grails Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <discovery label="Groovy/Grails Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
    </url>
    
    <requires>

--- a/features/org.springsource.ggts.package.e3.8/feature.xml
+++ b/features/org.springsource.ggts.package.e3.8/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Groovy/Grails Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
-      <discovery label="Groovy/Grails Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <update label="Groovy/Grails Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <discovery label="Groovy/Grails Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
    </url>
    
    <requires>

--- a/features/org.springsource.ggts.package.e4.2/feature.xml
+++ b/features/org.springsource.ggts.package.e4.2/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Groovy/Grails Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
-      <discovery label="Groovy/Grails Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <update label="Groovy/Grails Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <discovery label="Groovy/Grails Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
    </url>
    
    <requires>

--- a/features/org.springsource.ggts.package.e4.3/feature.xml
+++ b/features/org.springsource.ggts.package.e4.3/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Groovy/Grails Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.3"/>
-      <discovery label="Groovy/Grails Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.3"/>
+      <update label="Groovy/Grails Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.3"/>
+      <discovery label="Groovy/Grails Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.3"/>
    </url>
    
    <requires>

--- a/features/org.springsource.ggts.package.e4.4/feature.xml
+++ b/features/org.springsource.ggts.package.e4.4/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Groovy/Grails Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.3"/>
-      <discovery label="Groovy/Grails Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.3"/>
+      <update label="Groovy/Grails Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.3"/>
+      <discovery label="Groovy/Grails Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.3"/>
    </url>
    
    <requires>

--- a/features/org.springsource.ggts.package.e4.5/feature.xml
+++ b/features/org.springsource.ggts.package.e4.5/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Groovy/Grails Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
-      <discovery label="Groovy/Grails Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <update label="Groovy/Grails Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <discovery label="Groovy/Grails Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
    </url>
    
    <requires>

--- a/features/org.springsource.ggts.product/category.xml
+++ b/features/org.springsource.ggts.product/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The Groovy/Grails Tool Suite is the next generation IDE that helps you focus 
     your development work with the Groovy/Grails projects.
   </description>

--- a/features/org.springsource.sts.package.e3.6/feature.xml
+++ b/features/org.springsource.sts.package.e3.6/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <update label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
    </url>
    
    <includes id="org.eclipse.platform" version="0.0.0" />

--- a/features/org.springsource.sts.package.e3.7/feature.xml
+++ b/features/org.springsource.sts.package.e3.7/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <update label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e3.8/feature.xml
+++ b/features/org.springsource.sts.package.e3.8/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e3.8"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e3.8"/>
+      <update label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e3.8"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e3.8"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.2/feature.xml
+++ b/features/org.springsource.sts.package.e4.2/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <update label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://dist.springsource.com/release/TOOLS/update/e4.2"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.3/feature.xml
+++ b/features/org.springsource.sts.package.e4.3/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.3"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.3"/>
+      <update label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.3"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.3"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.4/feature.xml
+++ b/features/org.springsource.sts.package.e4.4/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.4"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.4"/>
+      <update label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.4"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.4"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.5-internal/feature.xml
+++ b/features/org.springsource.sts.package.e4.5-internal/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <update label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.5/feature.xml
+++ b/features/org.springsource.sts.package.e4.5/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <update label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.6-internal/feature.xml
+++ b/features/org.springsource.sts.package.e4.6-internal/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <update label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.5"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.6/feature.xml
+++ b/features/org.springsource.sts.package.e4.6/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.6"/>
-      <discovery label="SpringSource Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.6"/>
+      <update label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.6"/>
+      <discovery label="SpringSource Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.6"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.7/feature.xml
+++ b/features/org.springsource.sts.package.e4.7/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Spring Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.7"/>
-      <discovery label="Spring Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.7"/>
+      <update label="Spring Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.7"/>
+      <discovery label="Spring Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.7"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.package.e4.8/feature.xml
+++ b/features/org.springsource.sts.package.e4.8/feature.xml
@@ -19,8 +19,8 @@
    </license>
 
    <url>
-      <update label="Spring Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.8"/>
-      <discovery label="Spring Tool Suite Updates" url="http://download.springsource.com/release/TOOLS/update/e4.8"/>
+      <update label="Spring Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.8"/>
+      <discovery label="Spring Tool Suite Updates" url="https://download.springsource.com/release/TOOLS/update/e4.8"/>
    </url>
    
    <requires>

--- a/features/org.springsource.sts.product.e4.10/category.xml
+++ b/features/org.springsource.sts.product.e4.10/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.11/category.xml
+++ b/features/org.springsource.sts.product.e4.11/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.4/category.xml
+++ b/features/org.springsource.sts.product.e4.4/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.5-internal/category.xml
+++ b/features/org.springsource.sts.product.e4.5-internal/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.5/category.xml
+++ b/features/org.springsource.sts.product.e4.5/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.6-internal/category.xml
+++ b/features/org.springsource.sts.product.e4.6-internal/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.6/category.xml
+++ b/features/org.springsource.sts.product.e4.6/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.7/category.xml
+++ b/features/org.springsource.sts.product.e4.7/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.8/category.xml
+++ b/features/org.springsource.sts.product.e4.8/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.e4.9/category.xml
+++ b/features/org.springsource.sts.product.e4.9/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product.java8/category.xml
+++ b/features/org.springsource.sts.product.java8/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/features/org.springsource.sts.product/category.xml
+++ b/features/org.springsource.sts.product/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-  <description url="http://www.springsource.com/products/sts">
+  <description url="https://www.springsource.com/products/sts">
     The SpringSource Tool Suite is the next generation IDE that helps you focus 
     your development work with the Spring Portfolio.
   </description>

--- a/plugins/org.springsource.ggts/build-helper.xml
+++ b/plugins/org.springsource.ggts/build-helper.xml
@@ -61,7 +61,7 @@
 		<!-- <echo message="getDependenciesHelper.xml: basedir = ${basedir}"/> -->
 		<!-- requires the following params to be set -->
 		<!--
-			<property name="url"/> [url to download and unpack, eg., http://.../.../foo.zip]
+			<property name="url"/> [url to download and unpack, eg., https://.../.../foo.zip]
 			<property name="file"/> [filename of the url to download and unpack, eg., foo.zip]
     	-->
 		<!-- get the zip or tar.gz from the remote server if it's not already been downloaded -->

--- a/plugins/org.springsource.sts/build-helper.xml
+++ b/plugins/org.springsource.sts/build-helper.xml
@@ -61,7 +61,7 @@
 		<!-- <echo message="getDependenciesHelper.xml: basedir = ${basedir}"/> -->
 		<!-- requires the following params to be set -->
 		<!--
-			<property name="url"/> [url to download and unpack, eg., http://.../.../foo.zip]
+			<property name="url"/> [url to download and unpack, eg., https://.../.../foo.zip]
 			<property name="file"/> [filename of the url to download and unpack, eg., foo.zip]
     	-->
 		<!-- get the zip or tar.gz from the remote server if it's not already been downloaded -->

--- a/releng/org.springsource.sts.site.limited/site.xml
+++ b/releng/org.springsource.sts.site.limited/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-	<description url="http://www.springsource.com/products/sts">
+	<description url="https://www.springsource.com/products/sts">
 		The SpringSource Tool Suite is the next generation IDE that helps you focus 
 		your development work with the Spring Portfolio.
 	</description>

--- a/releng/org.springsource.sts.site/site.xml
+++ b/releng/org.springsource.sts.site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site pack200="true">
-	<description url="http://www.springsource.com/products/sts">
+	<description url="https://www.springsource.com/products/sts">
 		The SpringSource Tool Suite is the next generation IDE that helps you focus 
 		your development work with the Spring Portfolio.
 	</description>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://sha256timestamp.ws.symantec.com/sha256/timestamp (InvalidMediaTypeException) with 1 occurrences migrated to:  
  https://sha256timestamp.ws.symantec.com/sha256/timestamp ([https](https://sha256timestamp.ws.symantec.com/sha256/timestamp) result ConnectTimeoutException).
* http://.../.../foo.zip (UnknownHostException) with 2 occurrences migrated to:  
  https://.../.../foo.zip ([https](https://.../.../foo.zip) result UnknownHostException).
* http://proxy.eng.vmware.com:3128 (UnknownHostException) with 2 occurrences migrated to:  
  https://proxy.eng.vmware.com:3128 ([https](https://proxy.eng.vmware.com:3128) result UnknownHostException).
* http://dist.springsource.com/release/TOOLS/update/e3.8 (403) with 2 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/update/e3.8 ([https](https://dist.springsource.com/release/TOOLS/update/e3.8) result 403).
* http://dist.springsource.com/release/TOOLS/update/e4.2 (403) with 12 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/update/e4.2 ([https](https://dist.springsource.com/release/TOOLS/update/e4.2) result 403).
* http://download.springsource.com/release/TOOLS/update/e4.3 (403) with 6 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/update/e4.3 ([https](https://download.springsource.com/release/TOOLS/update/e4.3) result 403).
* http://download.springsource.com/release/TOOLS/update/e4.4 (403) with 2 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/update/e4.4 ([https](https://download.springsource.com/release/TOOLS/update/e4.4) result 403).
* http://download.springsource.com/release/TOOLS/update/e4.5 (403) with 8 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/update/e4.5 ([https](https://download.springsource.com/release/TOOLS/update/e4.5) result 403).
* http://download.springsource.com/release/TOOLS/update/e4.6 (403) with 2 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/update/e4.6 ([https](https://download.springsource.com/release/TOOLS/update/e4.6) result 403).
* http://download.springsource.com/release/TOOLS/update/e4.7 (403) with 2 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/update/e4.7 ([https](https://download.springsource.com/release/TOOLS/update/e4.7) result 403).
* http://download.springsource.com/release/TOOLS/update/e4.8 (403) with 2 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/update/e4.8 ([https](https://download.springsource.com/release/TOOLS/update/e4.8) result 403).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springsource.com/products/sts with 15 occurrences migrated to:  
  https://www.springsource.com/products/sts ([https](https://www.springsource.com/products/sts) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.osgi.org/xmlns/scr/v1.1.0 with 2 occurrences